### PR TITLE
Fix namespace error

### DIFF
--- a/src/Element/RichTextArea.php
+++ b/src/Element/RichTextArea.php
@@ -11,10 +11,9 @@
  */
 namespace Vegas\Forms\Element;
 
-use \Phalcon\Forms\Element\TextArea;
 use Vegas\Forms\Decorator;
 
-class RichTextArea extends TextArea implements Decorator\DecoratedInterface
+class RichTextArea extends \Phalcon\Forms\Element\TextArea implements Decorator\DecoratedInterface
 {
     use Decorator\DecoratedTrait;
 


### PR DESCRIPTION
Fixes the following fatal error:

Fatal error: Cannot use Phalcon\Forms\Element\TextArea as TextArea because the name is already in use in forms/src/Element/RichTextArea.php on line 14
